### PR TITLE
Fix context export

### DIFF
--- a/components/logic/index.ts
+++ b/components/logic/index.ts
@@ -7,4 +7,5 @@ export {
   StreamingAvatarSessionState,
   StreamingAvatarProvider,
   MessageSender,
+  useStreamingAvatarContext,
 } from "./context";


### PR DESCRIPTION
## Summary
- export `useStreamingAvatarContext` from the main logic barrel

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684218f351f08328b858779338af40b2