### PR TITLE
Add language selection to InteractiveAvatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ NOTE: Make sure you have enter your token into the `.env` file and run `npm run 
 
 To start your 'session' with a Interactive Avatar, first click the 'start' button. If your HeyGen API key is entered into the Server's .env file, then you should see our demo Interactive Avatar appear.
 
+This demo is locked to a single avatar, knowledge base and voice. You can
+choose the conversation language before starting the session.
+
 If you want to see a different Avatar or try a different voice, you can close the session and enter the IDs and then 'start' the session again. Please see below for information on where to retrieve different Avatar and voice IDs that you can use.
 
 ### Which Avatars can I use with this project?

--- a/components/InteractiveAvatar.tsx
+++ b/components/InteractiveAvatar.tsx
@@ -19,8 +19,11 @@ import { useVoiceChat } from "./logic/useVoiceChat";
 import { StreamingAvatarProvider, StreamingAvatarSessionState } from "./logic";
 import { LoadingIcon } from "./Icons";
 import { MessageHistory } from "./AvatarSession/MessageHistory";
+import { Select } from "./Select";
 
 import { AVATARS } from "@/app/lib/constants";
+
+const SUPPORTED_LANGUAGES = ["en", "es", "fr"];
 
 const DEFAULT_CONFIG: StartAvatarRequest = {
   quality: AvatarQuality.Low,
@@ -44,6 +47,7 @@ function InteractiveAvatar() {
   const { startVoiceChat } = useVoiceChat();
 
   const [config, setConfig] = useState<StartAvatarRequest>(DEFAULT_CONFIG);
+  const [language, setLanguage] = useState<string>("en");
 
   const mediaStream = useRef<HTMLVideoElement>(null);
 
@@ -99,7 +103,7 @@ function InteractiveAvatar() {
         console.log(">>>>> Avatar end message:", event);
       });
 
-      await startAvatar(config);
+      await startAvatar({ ...DEFAULT_CONFIG, language });
 
       if (isVoiceChat) {
         await startVoiceChat();
@@ -136,13 +140,23 @@ function InteractiveAvatar() {
           {sessionState === StreamingAvatarSessionState.CONNECTED ? (
             <AvatarControls />
           ) : sessionState === StreamingAvatarSessionState.INACTIVE ? (
-            <div className="flex flex-row gap-4">
-              <Button onClick={() => startSessionV2(true)}>
-                Start Voice Chat
-              </Button>
-              <Button onClick={() => startSessionV2(false)}>
-                Start Text Chat
-              </Button>
+            <div className="flex flex-col items-center gap-4">
+              <Select
+                isSelected={(option) => option === language}
+                options={SUPPORTED_LANGUAGES}
+                placeholder="Select language"
+                renderOption={(option) => option}
+                value={language}
+                onSelect={(option) => setLanguage(option)}
+              />
+              <div className="flex flex-row gap-4">
+                <Button onClick={() => startSessionV2(true)}>
+                  Start Voice Chat
+                </Button>
+                <Button onClick={() => startSessionV2(false)}>
+                  Start Text Chat
+                </Button>
+              </div>
             </div>
           ) : (
             <LoadingIcon />


### PR DESCRIPTION
## Summary
- allow choosing a conversation language before starting the avatar
- wire selected language into `startSessionV2`
- document how only the language can be changed

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68420f4f7df48328844057af67f1e3f2