### PR TITLE
Add language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ NOTE: Make sure you have enter your token into the `.env` file and run `npm run 
 
 To start your 'session' with a Interactive Avatar, first click the 'start' button. If your HeyGen API key is entered into the Server's .env file, then you should see our demo Interactive Avatar appear.
 
-If you want to see a different Avatar or try a different voice, you can close the session and enter the IDs and then 'start' the session again. Please see below for information on where to retrieve different Avatar and voice IDs that you can use.
+Use the dropdown to select the desired language before starting.
+
+The demo is locked to one avatar, knowledge base and voice configuration. Before starting a session you can choose a language, but the avatar and voice remain fixed.
 
 ### Which Avatars can I use with this project?
 

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -21,6 +21,8 @@ export const AVATARS = [
   },
 ];
 
+export const LANGUAGES = ["en", "es", "fr"];
+
 export const STT_LANGUAGE_LIST = [
   { label: "Bulgarian", value: "bg", key: "bg" },
   { label: "Chinese", value: "zh", key: "zh" },

--- a/components/InteractiveAvatar.tsx
+++ b/components/InteractiveAvatar.tsx
@@ -11,7 +11,6 @@ import { useEffect, useRef, useState } from "react";
 import { useMemoizedFn, useUnmount } from "ahooks";
 
 import { Button } from "./Button";
-import { AvatarConfig } from "./AvatarConfig";
 import { AvatarVideo } from "./AvatarSession/AvatarVideo";
 import { useStreamingAvatarSession } from "./logic/useStreamingAvatarSession";
 import { AvatarControls } from "./AvatarSession/AvatarControls";
@@ -20,7 +19,8 @@ import { StreamingAvatarProvider, StreamingAvatarSessionState } from "./logic";
 import { LoadingIcon } from "./Icons";
 import { MessageHistory } from "./AvatarSession/MessageHistory";
 
-import { AVATARS } from "@/app/lib/constants";
+import { AVATARS, LANGUAGES } from "@/app/lib/constants";
+import { Select } from "./Select";
 
 const DEFAULT_CONFIG: StartAvatarRequest = {
   quality: AvatarQuality.Low,
@@ -43,7 +43,7 @@ function InteractiveAvatar() {
     useStreamingAvatarSession();
   const { startVoiceChat } = useVoiceChat();
 
-  const [config, setConfig] = useState<StartAvatarRequest>(DEFAULT_CONFIG);
+  const [language, setLanguage] = useState<string>("en");
 
   const mediaStream = useRef<HTMLVideoElement>(null);
 
@@ -99,7 +99,7 @@ function InteractiveAvatar() {
         console.log(">>>>> Avatar end message:", event);
       });
 
-      await startAvatar(config);
+      await startAvatar({ ...DEFAULT_CONFIG, language });
 
       if (isVoiceChat) {
         await startVoiceChat();
@@ -126,24 +126,31 @@ function InteractiveAvatar() {
     <div className="w-full flex flex-col gap-4">
       <div className="flex flex-col rounded-xl bg-zinc-900 overflow-hidden">
         <div className="relative w-full aspect-video overflow-hidden flex flex-col items-center justify-center">
-          {sessionState !== StreamingAvatarSessionState.INACTIVE ? (
+          {sessionState !== StreamingAvatarSessionState.INACTIVE && (
             <AvatarVideo ref={mediaStream} />
-          ) : (
-            <AvatarConfig config={config} onConfigChange={setConfig} />
           )}
         </div>
         <div className="flex flex-col gap-3 items-center justify-center p-4 border-t border-zinc-700 w-full">
           {sessionState === StreamingAvatarSessionState.CONNECTED ? (
             <AvatarControls />
           ) : sessionState === StreamingAvatarSessionState.INACTIVE ? (
-            <div className="flex flex-row gap-4">
-              <Button onClick={() => startSessionV2(true)}>
-                Start Voice Chat
-              </Button>
-              <Button onClick={() => startSessionV2(false)}>
-                Start Text Chat
-              </Button>
-            </div>
+            <>
+              <Select
+                options={LANGUAGES}
+                renderOption={(option) => option}
+                onSelect={(option) => setLanguage(option)}
+                isSelected={(option) => option === language}
+                value={language}
+              />
+              <div className="flex flex-row gap-4">
+                <Button onClick={() => startSessionV2(true)}>
+                  Start Voice Chat
+                </Button>
+                <Button onClick={() => startSessionV2(false)}>
+                  Start Text Chat
+                </Button>
+              </div>
+            </>
           ) : (
             <LoadingIcon />
           )}


### PR DESCRIPTION
## Summary
- define supported languages constant
- add language state to InteractiveAvatar and choose with a drop-down
- start avatar sessions with the selected language
- mention language selection in README
- remove configuration UI so only language can be chosen before a session

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec9544788328bf7128e6a9821612