### PR TITLE
Add MongoDB connection via Mongoose

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 HEYGEN_API_KEY="your Heygen API key"
 NEXT_PUBLIC_BASE_API_URL=https://api.heygen.com
+DATABASE_URL="your database connection string"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,21 @@ Feel free to play around with the existing code and please leave any feedback fo
 
 4. Enter your HeyGen Enterprise API Token in the `.env` file. Replace `HEYGEN_API_KEY` with your API key. This will allow the Client app to generate secure Access Tokens with which to create interactive sessions.
 
-   You can retrieve either the API Key by logging in to HeyGen and navigating to this page in your settings: [https://app.heygen.com/settings?from=&nav=Subscriptions%20%26%20API]. 
+   You can retrieve either the API Key by logging in to HeyGen and navigating to this page in your settings: [https://app.heygen.com/settings?from=&nav=Subscriptions%20%26%20API].
 
-5. (Optional) If you would like to use the OpenAI features, enter your OpenAI Api Key in the `.env` file.
+5. Add your database connection string in the `.env` file as `DATABASE_URL`. This will be used by the server API routes for storing generated access tokens.
 
-6. Run `npm run dev`
+6. (Optional) If you would like to use the OpenAI features, enter your OpenAI Api Key in the `.env` file.
+
+7. Run `npm run dev`
+
+### Environment variables
+
+```
+HEYGEN_API_KEY=your Heygen API key
+NEXT_PUBLIC_BASE_API_URL=https://api.heygen.com
+DATABASE_URL=your database connection string
+```
 
 ### Starting sessions
 

--- a/app/api/get-access-token/route.ts
+++ b/app/api/get-access-token/route.ts
@@ -1,3 +1,6 @@
+import connect from "@/lib/db";
+import Token from "@/models/Token";
+
 const HEYGEN_API_KEY = process.env.HEYGEN_API_KEY;
 
 export async function POST() {
@@ -17,6 +20,9 @@ export async function POST() {
     console.log("Response:", res);
 
     const data = await res.json();
+
+    await connect();
+    await Token.create({ token: data.data.token });
 
     return new Response(data.data.token, {
       status: 200,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,26 @@
+import mongoose from "mongoose";
+
+const { DATABASE_URL } = process.env;
+
+if (!DATABASE_URL) {
+  throw new Error("DATABASE_URL is not defined");
+}
+
+let cached = (global as any).mongoose;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+async function connect() {
+  if (cached.conn) return cached.conn;
+
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(DATABASE_URL);
+  }
+  cached.conn = await cached.promise;
+
+  return cached.conn;
+}
+
+export default connect;

--- a/models/Token.ts
+++ b/models/Token.ts
@@ -1,0 +1,8 @@
+import { Schema, model, models } from "mongoose";
+
+const TokenSchema = new Schema({
+  token: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default models.Token || model("Token", TokenSchema);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-switch": "^1.1.4",
     "@radix-ui/react-toggle-group": "^1.1.3",
     "ahooks": "^3.8.4",
+    "mongoose": "^8.15.1",
     "next": "^15.3.0",
     "openai": "^4.52.1",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- add `mongoose` dependency for DB access
- configure `.env` with `DATABASE_URL`
- setup DB client in `lib/db.ts`
- store generated tokens in MongoDB
- document DB setup in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68421f0207d48328841ed6bed47a8826